### PR TITLE
Retrieve all emails from outlook (not only inbox)

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -124,7 +124,7 @@ pub async fn refresh_user(db: &DatabaseConnection, user: &mut User) -> DataResul
         if subscriptions.len() == 0 {
             let subscription = microsoft::subscribe(
                 &session.ms_user,
-                "/me/mailfolders('inbox')/messages?$filter=contains(subject, 'QCM')"
+                "/me/messages?$filter=contains(subject, 'QCM')"
             ).await?;
 
             db.add("subscriptions", json!({

--- a/src/user/microsoft.rs
+++ b/src/user/microsoft.rs
@@ -136,7 +136,7 @@ pub async fn refresh(user: &MSUser) -> MSResult<MSUser> {
 
 pub async fn get_mails(user: &MSUser, filter: &str, count: usize) -> MSResult<Vec<Mail>> {
     let url = format!(
-        "/me/mailFolders/inbox/messages?\
+        "/me/messages?\
             $select=id,receivedDateTime,hasAttachments,subject,sender&\
             $orderby=receivedDateTime desc&\
             $filter={}&\
@@ -150,7 +150,7 @@ pub async fn get_mails(user: &MSUser, filter: &str, count: usize) -> MSResult<Ve
 
 pub async fn get_first_attachment(user: &MSUser, mail: &Mail, filter: &str) -> MSResult<Option<Attachment>> {
     let url = format!(
-        "/me/mailFolders/inbox/messages/{}/attachments?$filter={}",
+        "/me/messages/{}/attachments?$filter={}",
         &mail.id,
         filter
     );


### PR DESCRIPTION
Actually, MCQ results are fetched from the inbox only.

As Outlook is not deleting emails automatically, removing the `mailFolders` parameters allows fetching all emails from in the inbox (not only the inbox). 